### PR TITLE
feat: switch from 'vsts-task-lib' to 'azure-pipelines-task-lib'

### DIFF
--- a/createpullrequest/createPullRequest.ts
+++ b/createpullrequest/createPullRequest.ts
@@ -6,7 +6,7 @@ import * as lim from "vso-node-api/interfaces/LocationsInterfaces";
 import * as ga from "vso-node-api/GitApi";
 import * as gi from "vso-node-api/interfaces/GitInterfaces";
 
-import * as tl from "vsts-task-lib/task";
+import * as tl from "azure-pipelines-task-lib/task";
 
 async function run() {
 

--- a/createpullrequest/package-lock.json
+++ b/createpullrequest/package-lock.json
@@ -48,6 +48,19 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "azure-pipelines-task-lib": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz",
+      "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
+      "requires": {
+        "minimatch": "3.0.4",
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "uuid": "^3.0.1"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -3441,19 +3454,6 @@
         "tunnel": "0.0.4",
         "typed-rest-client": "^0.12.0",
         "underscore": "1.8.3"
-      }
-    },
-    "vsts-task-lib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.7.0.tgz",
-      "integrity": "sha512-zQqgneIZG3VY84RoIzkQr07r9fDH3lPpj6Qp07K89co/vyFznWJYpkjcdxubQm1YvgNu/P0yWYLdDruHyGGdtA==",
-      "requires": {
-        "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "uuid": "^3.0.1"
       }
     },
     "wrappy": {

--- a/createpullrequest/package.json
+++ b/createpullrequest/package.json
@@ -12,9 +12,9 @@
   "author": "Sander Aernouts",
   "license": "ISC",
   "dependencies": {
+    "azure-pipelines-task-lib": "^2.8.0",
     "npm": "^6.10.0",
-    "vso-node-api": "^6.5.0",
-    "vsts-task-lib": "^2.7.0"
+    "vso-node-api": "^6.5.0"
   },
   "devDependencies": {
     "@types/node": "^10.14.12",

--- a/package.json
+++ b/package.json
@@ -13,5 +13,6 @@
   },
   "name": "vstsexttask",
   "private": true,
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "dependencies": {}
 }

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "git-buildtasks",
     "name": "git tasks",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "publisher": "sander-aernouts",
     "public" : false,
     "repository": {


### PR DESCRIPTION
`vsts-task-lib` is deprecated, now using `azure-pipelines-task-lib` instead