### PR TITLE
feat: switch from 'vso-node-api' to 'azure-devops-node-api'

### DIFF
--- a/createpullrequest/createPullRequest.ts
+++ b/createpullrequest/createPullRequest.ts
@@ -1,10 +1,10 @@
 import path = require("path");
 
-import * as vm from "vso-node-api";
-import * as lim from "vso-node-api/interfaces/LocationsInterfaces";
+import * as azdev from "azure-devops-node-api";
+import * as lim from "azure-devops-node-api/interfaces/LocationsInterfaces";
 
-import * as ga from "vso-node-api/GitApi";
-import * as gi from "vso-node-api/interfaces/GitInterfaces";
+import * as ga from "azure-devops-node-api/GitApi";
+import * as gi from "azure-devops-node-api/interfaces/GitInterfaces";
 
 import * as tl from "azure-pipelines-task-lib/task";
 
@@ -16,8 +16,8 @@ async function run() {
         throw `detected a repository provider that is not TfsGit. Provider "${provider}" is not supported.`;
     }
 
-    let vsts: vm.WebApi = await getWebApi();
-    let gitApi: ga.IGitApi = await vsts.getGitApi();
+    let azdevApi: azdev.WebApi = await getWebApi();
+    let gitApi: ga.IGitApi = await azdevApi.getGitApi();
 
     const project: string = getProject();
     const repositoryName = getRepositoryName();
@@ -102,23 +102,23 @@ function getEnv(name: string): string {
     return val;
 }
 
-async function getWebApi(): Promise<vm.WebApi> {
+async function getWebApi(): Promise<azdev.WebApi> {
     let serverUrl = getEnv("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI");
     console.log(`connecting to VSTS web API"s on server: "${serverUrl}"`);
     return await getApi(serverUrl);
 }
 
-async function getApi(serverUrl: string): Promise<vm.WebApi> {
-    return new Promise<vm.WebApi>(async (resolve, reject) => {
+async function getApi(serverUrl: string): Promise<azdev.WebApi> {
+    return new Promise<azdev.WebApi>(async (resolve, reject) => {
         try {
             let token = tl.getEndpointAuthorizationParameter("SystemVssConnection", "AccessToken", false);
-            let authHandler = vm.getPersonalAccessTokenHandler(token);
+            let authHandler = azdev.getPersonalAccessTokenHandler(token);
             let option = undefined;
-            let vsts: vm.WebApi = new vm.WebApi(serverUrl, authHandler, option);
-            let connData: lim.ConnectionData = await vsts.connect();
+            let azdevApi: azdev.WebApi = new azdev.WebApi(serverUrl, authHandler, option);
+            let connData: lim.ConnectionData = await azdevApi.connect();
 
             console.log(`authenticated as user: "${connData.authenticatedUser.providerDisplayName}"`);
-            resolve(vsts);
+            resolve(azdevApi);
         }
         catch (err) {
             reject(err);

--- a/createpullrequest/package-lock.json
+++ b/createpullrequest/package-lock.json
@@ -48,6 +48,27 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "azure-devops-node-api": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-9.0.1.tgz",
+      "integrity": "sha512-0veE4EWHObJxzwgHlydG65BjNMuLPkR1nzcQ2K51PIho1/F4llpKt3pelC30Vbex5zA9iVgQ9YZGlkkvOBSksw==",
+      "requires": {
+        "tunnel": "0.0.4",
+        "typed-rest-client": "1.2.0",
+        "underscore": "1.8.3"
+      },
+      "dependencies": {
+        "typed-rest-client": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
+          "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
+          "requires": {
+            "tunnel": "0.0.4",
+            "underscore": "1.8.3"
+          }
+        }
+      }
+    },
     "azure-pipelines-task-lib": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz",
@@ -335,15 +356,6 @@
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
       "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
     },
-    "typed-rest-client": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.12.0.tgz",
-      "integrity": "sha1-Y3b1Un9CfaEh3K/f1+QeEyHgcgw=",
-      "requires": {
-        "tunnel": "0.0.4",
-        "underscore": "1.8.3"
-      }
-    },
     "typescript": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
@@ -359,16 +371,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-    },
-    "vso-node-api": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.5.0.tgz",
-      "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
-      "requires": {
-        "tunnel": "0.0.4",
-        "typed-rest-client": "^0.12.0",
-        "underscore": "1.8.3"
-      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/createpullrequest/package.json
+++ b/createpullrequest/package.json
@@ -12,8 +12,8 @@
   "author": "Sander Aernouts",
   "license": "ISC",
   "dependencies": {
-    "azure-pipelines-task-lib": "^2.8.0",
-    "vso-node-api": "^6.5.0"
+    "azure-devops-node-api": "^9.0.1",
+    "azure-pipelines-task-lib": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^10.14.12",


### PR DESCRIPTION
`vso-node-api` was renamed to `azure-devops-node-api`, switching to the latest `azure-devops-node-api` package