### PR TITLE
feat: add repository selection as alternative way of selection the Azure repository

### DIFF
--- a/createpullrequest/task.json
+++ b/createpullrequest/task.json
@@ -18,6 +18,11 @@
     "demands": [],
     "groups": [
         {
+            "name": "repository",
+            "displayName": "Repository",
+            "isExpanded": true
+        },
+        {
             "name": "branches",
             "displayName": "Branches",
             "isExpanded": true
@@ -35,6 +40,46 @@
     ],
     "instanceNameFormat": "Create pull request",
     "inputs": [
+        {
+            "name": "repositorySelectionMethod",
+            "type": "radio",
+            "label": "Repository to use",
+            "required": true,
+            "defaultValue": "currentBuild",
+            "options": {
+                "currentBuild": "Current build",
+                "select": "Select"
+            },
+            "helpMarkDown": "The method for selecting the Git repository. `Current build` will use the repository for which the current build is configured. `Select` will allow you to select an Azure Repository from your account.",
+            "groupName": "repository"
+        },
+        {
+            "name": "projectId",
+            "type": "picklist",
+            "label": "Project",
+            "defaultValue": "",
+            "properties": {
+                "EditableOptions": "True",
+                "DisableManageLink": "True"
+            },
+            "required": true,
+            "helpMarkDown": "Project that contains the git repository you want to create a pull request for.",
+            "groupName": "repository",
+            "visibleRule": "repositorySelectionMethod = select"
+        },
+        {
+            "name": "gitRepositoryId",
+            "type": "picklist",
+            "label": "Repository",
+            "defaultValue": "","properties": {
+                "EditableOptions": "True",
+                "DisableManageLink": "True"
+            }            ,
+            "required": true,
+            "helpMarkDown": "Git repository you want to create a pull request for",
+            "groupName": "repository",
+            "visibleRule": "repositorySelectionMethod = select"
+        },
         {
             "name": "sourceBranch",
             "type": "string",
@@ -104,6 +149,29 @@
             "helpMarkDown": "Perform a squash merge when merging the pull request into the target branch",
             "groupName": "completion"
         }
+    ],
+    "dataSourceBindings": [
+        {
+            "endpointId": "tfs:teamfoundation",
+            "target": "projectId",
+            "endpointUrl": "{{endpoint.url}}/_apis/projects?$skip={{skip}}&$top=1000",
+            "resultSelector": "jsonpath:$.value[?(@.state=='wellFormed')]",
+            "resultTemplate": "{ \"Value\" : \"{{{id}}}\", \"DisplayValue\" : \"{{{name}}}\" }",
+            "callbackContextTemplate": "{\"skip\": \"{{add skip 1000}}\"}",
+            "callbackRequiredTemplate": "{{isEqualNumber result.count 1000}}",
+            "initialContextTemplate": "{\"skip\": \"0\"}"
+            },
+            {
+            "endpointId": "tfs:teamfoundation",
+            "target": "gitRepositoryId",
+            "endpointUrl": "{{endpoint.url}}/{{project}}/_apis/git/repositories",
+            "resultSelector": "jsonpath:$.value[*]",
+            "parameters": {
+                "project": "$(projectId)"
+            },
+            "resultTemplate": "{ \"Value\" : \"{{{id}}}\", \"DisplayValue\" : \"{{{name}}}\" }"
+        }
+
     ],
     "execution": {
         "Node": {

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
     "major":  0,
-    "minor":  2
+    "minor":  3
 }

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "git-buildtasks",
     "name": "git tasks",
-    "version": "1.0.7",
+    "version": "1.0.9",
     "publisher": "sander-aernouts",
     "public" : false,
     "repository": {


### PR DESCRIPTION
Currently the task will always use the repository configured for the build. Adding a way for users to select which repository they want use instead of forcing the repository configured for the build will allow users to also use this better in a release pipeline.

The default option will still be to use the repository that was configured for the build but an additional option will be added to instead pick a project and a Azure repository from a pickList type input.